### PR TITLE
Add Prettier configuration

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,2 @@
+.next/
+node_modules/

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "arrowParens": "always"
+}


### PR DESCRIPTION
## Description
Just as the title says! I've added formatting options for Prettier and also made it ignore the `.next/` and `node_modules/` directories.

### Configuration
| Setting             | Value       |
|---------------------|-------------|
| `tabWidth`          | `2`         |
| `useTabs`           | `false`     |
| `semi`              | `true`      |
| `singleQuote`       | `false`     |
| `quoteProps`        | `as-needed` |
| `jsxSingleQuote`    | `false`     |
| `trailingComma`     | `es5`       |
| `bracketSpacing`    | `true`      |
| `jsxBracketSpacing` | `false`     |
| `arrowParens`       | `always`    |